### PR TITLE
Fix build `No such file or directory` on run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Chrome Extension for inspecting Repro Web SDK",
   "main": "index.js",
   "scripts": {
-    "build": "zip -r build/web-sdk-inspector.zip src"
+    "build": "mkdir -p build/ && zip -r build/web-sdk-inspector.zip src"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Could not run `npm run build` at first.Because the `build/` directory did not create.

```
╍ npm run build

> repro-web-sdk-inspector@1.0.1 build /Users/eccyan/dev/repro-web-sdk-inspector
> zip -r build/web-sdk-inspector.zip src

zip I/O error: No such file or directory
zip error: Could not create output file (build/web-sdk-inspector.zip)
npm ERR! code ELIFECYCLE
npm ERR! errno 15
npm ERR! repro-web-sdk-inspector@1.0.1 build: `zip -r build/web-sdk-inspector.zip src`
npm ERR! Exit status 15
npm ERR!
npm ERR! Failed at the repro-web-sdk-inspector@1.0.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/eccyan/.npm/_logs/2019-01-28T11_04_44_928Z-debug.log
```